### PR TITLE
Fix bad error reference in `replacefile_stub.go`

### DIFF
--- a/pkg/replacefile/replacefile_stub.go
+++ b/pkg/replacefile/replacefile_stub.go
@@ -13,7 +13,7 @@ import (
 var (
 	errOnlyWindows                    = errors.New("replacefile: only implemented on Windows")
 	ErrUnableToMoveReplacement  error = errOnlyWindows
-	ErrUnableToMoveReplacement2 error = errOnlyOnWindows
+	ErrUnableToMoveReplacement2 error = errOnlyWindows
 	ErrUnableToRemoveReplaced   error = errOnlyWindows
 )
 


### PR DESCRIPTION
`errOnlyOnWindows` was used, but the error name is actually `errOnlyWindows`
